### PR TITLE
Fix typo (extra comma) in CMakePreset.json

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ find_package(Threads)
 include(cmake/lapack.cmake)
 
 # -- Scalapack / MPI
-
+set(parallel off CACHE BOOL "Enable MPI")
 if(parallel)
   include(cmake/mpi.cmake)
   include(cmake/scalapack.cmake)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,10 @@
       "name": "default",
       "hidden": true,
       "binaryDir": "${sourceDir}/build",
-      "generator": "Ninja"
+      "generator": "Ninja",
+      "cacheVariables": {
+        "parallel": "off"
+      }
     },
     {
       "name": "build",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -19,7 +19,7 @@
       "description": "Build all external libraries (except MPI) without searching for existing libraries.",
       "cacheVariables": {
         "lapack_external": "on",
-        "scalapack_external": "on",
+        "scalapack_external": "on"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,12 +68,14 @@
       "inherits": "build",
       "displayName": "Intel oneAPI compiler: Linux/MacOS",
       "description": "build with Intel oneAPI on Linux/MacOS",
+      "cacheVariables": {
+        "lapack_external": "off",
+        "scalapack_external": "off"
+      },
       "environment": {
         "CC": "icc",
         "FC": "ifort",
         "CXX": "icpc",
-        "lapack_external": "off",
-        "scalapack_external": "off",
         "LAPACK_ROOT": "$env{MKLROOT}",
         "SCLAPACK_ROOT": "$env{MKLROOT}",
         "MPI_ROOT": "$env{I_MPI_ROOT}"
@@ -81,12 +83,20 @@
     },
     {
       "name": "intelwin",
-      "inherits": ["intel", "build"],
+      "inherits": "default",
       "displayName": "Intel oneAPI compiler: Windows",
       "description": "build with Intel oneAPI on Windows",
+      "cacheVariables": {
+        "lapack_external": "off",
+        "scalapack_external": "off"
+      },
       "environment": {
         "CC": "icl",
-        "CXX": "icl"
+        "FC": "ifort",
+        "CXX": "icl",
+        "LAPACK_ROOT": "$env{ONEAPI_ROOT}mkl/latest",
+        "SCLAPACK_ROOT": "$env{ONEAPI_ROOT}mkl/latest",
+        "MPI_ROOT": "$env{ONEAPI_ROOT}mpi/latest"
       }
     },
     {


### PR DESCRIPTION
The JSON file for presets is broken because of an extra comma.